### PR TITLE
Use `source` instead of `body` as parameter key

### DIFF
--- a/app.js
+++ b/app.js
@@ -64,7 +64,7 @@ twitter.stream('statuses/filter', params, function(stream) {
     }
 
     var message = {
-      body: text
+      source: text
     };
 
     _(hookConfigurations).forEach(function(hook) {


### PR DESCRIPTION
Now `body` seems to be deprecated.
I got the following response when I use `body` for the generic hook:

```
{"message":"WARNING: \"body\" is deprecated. Use \"source\" instead."}
```
